### PR TITLE
Tooltip breakword fix

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -27,6 +27,7 @@
 	  margin-left: -75px;
 	  opacity: 0;
 	  transition: opacity 0.3s;
+	  overflow-wrap: break-word;
 	}
 
 	.tooltip .tooltiptext::after {


### PR DESCRIPTION
Here are the coverage in browsers to the overflow-wrap support:
https://caniuse.com/#feat=mdn-css_properties_overflow-wrap_break-word